### PR TITLE
Fix import for process_banking_data in methodology page

### DIFF
--- a/pages/methodology.py
+++ b/pages/methodology.py
@@ -9,7 +9,7 @@ import warnings
 warnings.filterwarnings('ignore')
 
 # Import our data processor
-from data_processor import BankingDataProcessor
+from data_processor import BankingDataProcessor, process_banking_data
 
 # Page configuration
 st.set_page_config(


### PR DESCRIPTION
## Summary
- include `process_banking_data` in the data_processor import for `pages/methodology.py`

## Testing
- `python -m py_compile pages/methodology.py`
- `python -m py_compile data_processor.py`
- `python -m py_compile pages/dashboard.py pages/machinelearning.py`


------
https://chatgpt.com/codex/tasks/task_e_685f2a784174832fa40fd8f4330b2c8f