### PR TITLE
Update default bank name in methodology

### DIFF
--- a/pages/methodology.py
+++ b/pages/methodology.py
@@ -880,7 +880,7 @@ with tab6:
         demo_banks = st.multiselect(
             "Choose banks to analyze:",
             options=processor.get_available_banks(),
-            default=['JPMorgan Chase', 'HSBC', 'Deutsche Bank'],
+            default=['JPMorgan Chase', 'HSBC Holdings', 'Deutsche Bank'],
             max_selections=5
         )
         


### PR DESCRIPTION
## Summary
- update the default bank list in the demo multiselect widget on methodology page

## Testing
- `python test_installation.py`

------
https://chatgpt.com/codex/tasks/task_e_685f36e441b4832f83ac10f61138dd73