### PR TITLE
Fix NaN handling for numpy arrays

### DIFF
--- a/data_processor.py
+++ b/data_processor.py
@@ -283,7 +283,14 @@ class BankingDataProcessor:
         if isinstance(returns, np.ndarray):
             returns = pd.Series(returns)
         
-        if len(returns) == 0 or (hasattr(returns, 'isna') and returns.isna().all()):
+        if len(returns) == 0:
+            return np.nan
+
+        # Handle NaNs for both pandas and numpy objects
+        if hasattr(returns, 'isna'):
+            if returns.isna().all():
+                return np.nan
+        elif np.isnan(returns).all():
             return np.nan
         
         # Clean the data


### PR DESCRIPTION
## Summary
- avoid calling `isna` on numpy arrays in `calculate_var`

## Testing
- `python test_installation.py`

------
https://chatgpt.com/codex/tasks/task_e_685f405a4188832f9b8d55978126fe90